### PR TITLE
Rebase on checkout@v4

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: ${{ inputs.fetch-depth }}
         ref: ${{ inputs.ref }}


### PR DESCRIPTION
## Changes introduced with this PR

* Rebase on checkout@v4; solves warning:

```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3
```

## Are you the owner of the code you are sending in, or do you have permission of the owner?

y